### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/watchiot/watchiot-repo-config.png?label=ready&title=Ready)](https://waffle.io/watchiot/watchiot-repo-config)
 [![Build Status](https://travis-ci.org/watchiot/watchiot-repo-config.svg?branch=master)](https://travis-ci.org/watchiot/watchiot-repo-config) [![Code Climate](https://codeclimate.com/github/watchiot/watchiot-repo/badges/gpa.svg)](https://codeclimate.com/github/watchiot/watchiot-repo)
 
 # Watchiot Repository of Configurations


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/watchiot/watchiot-repo-config

This was requested by a real person (user gorums) on waffle.io, we're not trying to spam you.
